### PR TITLE
Prevent UploadGateway from being created when cloudServices#tokenUrl is not provided

### DIFF
--- a/src/cloudservicesuploadadapter.js
+++ b/src/cloudservicesuploadadapter.js
@@ -41,6 +41,10 @@ export default class CloudServicesUploadAdapter extends Plugin {
 		const token = cloudServices.token;
 		const uploadUrl = cloudServices.uploadUrl || 'https://files.cke-cs.com/upload/';
 
+		if ( !token ) {
+			return;
+		}
+
 		this._uploadGateway = new CloudServicesUploadAdapter._UploadGateway( token, uploadUrl );
 
 		editor.plugins.get( FileRepository ).createAdapter = loader => {

--- a/tests/cloudservicesuploadadapter.js
+++ b/tests/cloudservicesuploadadapter.js
@@ -68,7 +68,7 @@ describe( 'CloudServicesUploadAdapter', () => {
 					plugins: [ CloudServicesUploadAdapter ]
 				} )
 				.then( editor => {
-					expect( UploadGatewayMock.lastToken ).to.be.an( 'undefined' );
+					expect( UploadGatewayMock.lastToken ).to.be.undefined;
 
 					return editor.destroy();
 				} );

--- a/tests/cloudservicesuploadadapter.js
+++ b/tests/cloudservicesuploadadapter.js
@@ -60,6 +60,20 @@ describe( 'CloudServicesUploadAdapter', () => {
 				} );
 		} );
 
+		it( 'should not set loader if there is no token', () => {
+			UploadGatewayMock.lastToken = undefined;
+
+			return ClassicTestEditor
+				.create( div, {
+					plugins: [ CloudServicesUploadAdapter ]
+				} )
+				.then( editor => {
+					expect( UploadGatewayMock.lastToken ).to.be.an( 'undefined' );
+
+					return editor.destroy();
+				} );
+		} );
+
 		it( 'should set the default uploadUrl', () => {
 			const expectedDefaultUrl = 'https://files.cke-cs.com/upload/';
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevented UploadGateway from being created when `cloudServices#tokenUrl` is not provided. Closes ckeditor/ckeditor5#2559.
